### PR TITLE
Added support for cloud powershell agent helloid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that the _'HelloID-Conn-Prov-Source-ADP-Workforce'_ implementation is based
 ### Todo
 
 - [X] Add _departments.ps1_
-- [ ] Add pagination for the _workerDemographics_ endpoint
+- [X] Add pagination for the _workerDemographics_ endpoint
 - [X] Add logic to obtain an AccessToken inluding a *.pfx certificate
 
 ## Table of contents
@@ -75,6 +75,16 @@ APD will register an application that's allowed to access the specified API's. _
 ### X.509 certificate / Private key
 
 The private key (*.pfx) belonging to the X.590 certificate must be used in order obtain an accesstoken.
+
+There are two options available to import the *.pfx:
+
+Option 1 called "Certificatepath" takes the path to the *.pfx on the machine on which the agent is configured.
+
+Option 2 called "Application PFX Certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.
+
+Execute the following code to get the base64 of your *.pfx file in your clipboard: [System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard
+
+To use option 2, leave option 1 empty.
 
 ### AccessToken
 

--- a/configuration.json
+++ b/configuration.json
@@ -36,7 +36,20 @@
       "label": "CertificatePath",
       "placeholder": "C:\\ADP.pfx",
       "description": "The location to the 'private key of the x.509 certificate' on the server where the HelloID agent and provisioning agent are running. Make sure to use the private key for the certificate that's used to generate a ClientID and ClientSecret and for activating the required API's",
-      "required": true
+      "required": false
+    }
+  },
+  {
+    "key": "PowerShellX509",
+    "type": "textarea",
+    "defaultValue": "",
+    "templateOptions": {
+      "label": "Application PFX Certificate",
+      "type": "password",
+      "placeholder": "<Base64 string export certificate>",
+      "description": "[System.Convert]::ToBase64String((get-content \"C:\\HelloID-ADP.pfx\" -Encoding Byte))",
+      "rows": 16,
+      "required": false
     }
   },
   {


### PR DESCRIPTION
Changed a couple of things, first of all i added an option in the configuration to import the base64 image of the ADP PFX. Powershell will create a certificate object together with the password. This removes the need of the on-prem helloid agent. The on-prem agent can still be used with the certificatepath configuration option. leave this option empty and fill the Application PFX Certificate option to use the cloud sollution.

Also added paging to the workers request, because without paging it leads to gateway errors.

Finally removed some functions and placed the code in the script section to make trouble shooting easier for the consultant. This code has also been optimized to improve performance (it now processes about 1500 persons a minute).

Updated the readme as well for the new certificate option.

Script is fully backwards compatible