### PR TITLE
Fix optional cloud agent readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ There are two options available to import the *.pfx:
 2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.</br>
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
-  > To use option 2: 
-  </br>- Leave option 1 empty.
+  > To use option 2: leave option 1 empty.
   </br>- Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
   ```powershell

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ There are two options available to import the *.pfx:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
   > To use option 2: leave option 1 empty.
   
-  Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+    Edit the person and department script:
+    Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
   ```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## Version
 | Version | Description | Date |
 | - | - | - |
+| 2.1.2   | Update readme, added opton for cloud agent | 13/12/2023  |
 | 2.1.1   | Update readme | 08/09/2023  |
 | 2.1.0   | Added support for cloud by using base64 pfx string | 06/09/2023  |
 | 2.0.1   | release of v2 | 13/07/2023  |
@@ -86,11 +87,18 @@ APD will register an application that's allowed to access the specified API's. _
 The private key (*.pfx) belonging to the X.590 certificate must be used in order obtain an accesstoken.
 
 There are two options available to import the *.pfx:
-1. Option 1 called "Certificatepath" takes the path to the *.pfx on the machine on which the agent is configured.
-2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.
+1. Option 1 called "Certificatepath" takes the path to the *.pfx on the machine on which the agent is configured. This requires the local on-premise agent.
+2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.</br>
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
-  > To use option 2, leave option 1 empty.
+  > To use option 2: 
+  </br>- Leave option 1 empty.
+  </br>- Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+
+  ```powershell
+    $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false
+    $dataset = $datasetJson.content | ConvertFrom-Json
+```
 
 ### AccessToken
 In order to retrieve data from the ADP Workforce API's, an AccessToken has to be obtained. The AccessToken is used for all consecutive calls to ADP Workforce. To obtain an AccessToken, we will need the ___ClientID___, ___ClientSecret___, ___The path to your pfx certificate___ and the ___password for the pfx certificate___.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ There are two options available to import the *.pfx:
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
   > To use option 2: leave option 1 empty.
+  
     </br>Edit the person and department script:
     </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ There are two options available to import the *.pfx:
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
   > To use option 2: leave option 1 empty.
-  </br>- Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+  
+  Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
   ```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ There are two options available to import the *.pfx:
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
   > To use option 2: leave option 1 empty.
-  
-    Edit the person and department script:
-    Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+    </br>Edit the person and department script:
+    </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
   ```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ There are two options available to import the *.pfx:
 2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.</br>
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
-  > To use option 2: leave option 1 empty.
+  </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
-  
-    </br>Edit the person and department script:
-    </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
-
-  ```powershell
+```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false
     $dataset = $datasetJson.content | ConvertFrom-Json
 ```
+  > To use option 2: leave option 1 empty.
+
+
+
 
 ### AccessToken
 In order to retrieve data from the ADP Workforce API's, an AccessToken has to be obtained. The AccessToken is used for all consecutive calls to ADP Workforce. To obtain an AccessToken, we will need the ___ClientID___, ___ClientSecret___, ___The path to your pfx certificate___ and the ___password for the pfx certificate___.

--- a/README.md
+++ b/README.md
@@ -89,17 +89,17 @@ The private key (*.pfx) belonging to the X.590 certificate must be used in order
 There are two options available to import the *.pfx:
 1. Option 1 called "Certificatepath" takes the path to the *.pfx on the machine on which the agent is configured. This requires the local on-premise agent.
 2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.</br>
-  </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
+  </br> To use option 2, follow the steps below:
+  </br>1. Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
-  </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+
+  </br>2. Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
 ```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false
     $dataset = $datasetJson.content | ConvertFrom-Json
 ```
   > To use option 2: leave option 1 empty.
-
-
 
 
 ### AccessToken

--- a/README.md
+++ b/README.md
@@ -90,10 +90,9 @@ There are two options available to import the *.pfx:
 1. Option 1 called "Certificatepath" takes the path to the *.pfx on the machine on which the agent is configured. This requires the local on-premise agent.
 2. Option 2 called "Base64 string of certificate" takes a base64 string of the *.pfx file, which powershell converts to a certificate object. This eliminates the need for a local on-premises agent.</br>
   </br> To use option 2, follow the steps below:
-  </br>1. Execute the following code to get the base64 of your *.pfx file in your clipboard:
+  </br>   1. Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
-
-  </br>2. Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
+  </br>   2. Replace line 281 and 282 from the person script and 260 and 261 from the department script with:
 
 ```powershell
     $datasetJson = Invoke-WebRequest @splatRestMethodParamete -verbose:$false

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ There are two options available to import the *.pfx:
   </br>Execute the following code to get the base64 of your *.pfx file in your clipboard:
   ```[System.Convert]::ToBase64String((get-content "C:\*.pfx" -Encoding Byte)) | Set-Clipboard```
   > To use option 2: leave option 1 empty.
+
   
     </br>Edit the person and department script:
     </br>Replace line 281 and 282 from the person script and 260 and 261 from the department script with:


### PR DESCRIPTION
For issue "Diacritical characters not imported correctly when running in cloud #10" I made some changes in the readme. Basically the default agent would be the on-premise agent, but when the customer wants to use the cloud agent, there is now an explanation what to change to get it work.